### PR TITLE
update package.json to allow Gatsby v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cross-env": "^5.1.4"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",


### PR DESCRIPTION
Confirmed this plugin works with Gatsby v4, but will not install without using `--force` or `--legacy-peer-deps` due to the peerDependencies version.