### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cross-env": "^5.1.4"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "axios": "^1.3.5",
-    "chalk": "^2.4.1",
+    "chalk": "^4.1.2",
     "gatsby-node-helpers": "^0.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "axios": "^0.18.0",
+    "axios": "^1.3.5",
     "chalk": "^2.4.1",
     "gatsby-node-helpers": "^0.3.0"
   },


### PR DESCRIPTION
Adds Gatsby 5 as a peer dependency to avoid having to install packages with `--legacy-peer-deps`. Also upgrades `axios` to address a critical security vulnerability that was fixed in v0.21.1, and upgrades `chalk`. Tested and works.